### PR TITLE
feat: add ability to set full path for output file

### DIFF
--- a/src/cli/commands/generate.mjs
+++ b/src/cli/commands/generate.mjs
@@ -56,7 +56,8 @@ export default {
         output: {
           alias: 'o',
           default: 'types.d.ts',
-          description: 'The name of the file to store definitions as',
+          description:
+            'The name of the file or full file path to store definitions as',
           type: 'string',
         },
         prettify: {

--- a/src/cli/io.mjs
+++ b/src/cli/io.mjs
@@ -17,8 +17,15 @@ export async function read(filepath) {
 }
 
 export async function write(filepath, input, opts) {
-  const outputPath = changeBasename(filepath, opts.output);
+  const outputPath =
+    path.dirname(opts.output) === '.'
+      ? // replace basename if output contains file name
+        changeBasename(filepath, opts.output)
+      : // use the full file path otherwise
+        opts.output;
+
   await fs.writeFile(outputPath, input);
+
   if (!opts.quiet) {
     process.stdout.write(
       chalk.green(`Written ${outputPath} for ${filepath}\n`),


### PR DESCRIPTION
First of all thanks for this amazing library @P0lip!

I've figured out that sometimes I need to pass a full file path to the output instead of having the file in the same directory as a spec. This PR adds this ability: you can now pass a file path as `output` option:

```bash
ruk-cuk generate path/to/input.json -o path/to/output.d.ts
```

This PR adds no breaking changes, so old configurations will work to:

```bash
ruk-cuk generate path/to/input.json -o some_file_name.d.ts
```